### PR TITLE
Bump TensorRT visible torch version

### DIFF
--- a/modules/utils.py
+++ b/modules/utils.py
@@ -58,7 +58,9 @@ def is_installed(package: str):
 def tensorrt_is_available():
     global logged_trt_warning
     tensorrt = is_installed("tensorrt")
-    version = LooseVersion("2") > LooseVersion(torch.__version__)
+    version = LooseVersion("2") > LooseVersion(torch.__version__) or LooseVersion(
+        "2.1"
+    ) <= LooseVersion(torch.__version__)
 
     if not tensorrt or not version:
         if not logged_trt_warning and tensorrt and config.get("tensorrt"):


### PR DESCRIPTION
Related issue: #69 

Though torch2.0 will raise `UnsupportedOperatorError` while exporting onnx, the nightly torch2.1 can use TensorRT normally.
It seems that torch has fixed the issue in their coming version.

TensorRT test with torch2.1 nightly:
```
TensorRT version: 8.6.1

...

======= Diagnostic Run torch.onnx.export version 2.1.0.dev20230511+cu118 =======
verbose: False, log level: Level.ERROR
======================= 0 NONE 0 NOTE 0 WARNING 0 ERROR ========================

[I] Folding Constants | Pass 1
[I] Inferring shapes in the model with `onnxruntime.tools.symbolic_shape_infer`.
    Note: To force Polygraphy to use `onnx.shape_inference` instead, set `allow_onnxruntime=False` or use the `--no-onnxruntime-shape-inference` command-line option.
[I]     Total Nodes | Original:  4544, After Folding:  3269 |  1275 Nodes Folded
[I] Folding Constants | Pass 2
[I]     Total Nodes | Original:  3269, After Folding:  2530 |   739 Nodes Folded
[I] Folding Constants | Pass 3
[I]     Total Nodes | Original:  2530, After Folding:  2530 |     0 Nodes Folded
Building TensorRT engine for models/accelerate/tensorrt/gsdf/Counterfeit-V2.5/onnx/unet.opt.onnx: models/accelerate/tensorrt/gsdf/Counterfeit-V2.5/engine/unet.plan
[W] onnx2trt_utils.cpp:374: Your ONNX model has been generated with INT64 weights, while TensorRT does not natively support INT64. Attempting to cast down to INT32.
[W] onnx2trt_utils.cpp:400: One or more weights outside the range of INT32 was clamped
[I]     Configuring with profiles: [Profile().add('sample', min=(2, 4, 32, 32), opt=(2, 4, 64, 64), max=(2, 4, 128, 128)).add('encoder_hidden_states', min=(2, 77, 768), opt=(2, 77, 768), max=(2, 77, 768)).add('timestep', min=[1], opt=[1], max=[1])]
[I] Building engine with configuration:
    Flags                  | [FP16]
    Engine Capability      | EngineCapability.DEFAULT
    Memory Pools           | [WORKSPACE: 10902.81 MiB, TACTIC_DRAM: 15101.81 MiB]
    Tactic Sources         | []
    Profiling Verbosity    | ProfilingVerbosity.DETAILED
    Preview Features       | [FASTER_DYNAMIC_SHAPES_0805, DISABLE_EXTERNAL_TACTIC_SOURCES_FOR_CORE_0805]
[W] TensorRT encountered issues when converting weights between types and that could affect accuracy.
[W] If this is not the desired behavior, please modify the weights or retrain with regularization to adjust the magnitude of the weights.
[W] Check verbose logs for the list of affected weights.
[W] - 224 weights are affected by this issue: Detected subnormal FP16 values.
[I] Finished engine building in 1063.897 seconds
[I] Saving engine to models/accelerate/tensorrt/gsdf/Counterfeit-V2.5/engine/unet.plan
```