### PR TITLE
Add Feature: Hires.fix

### DIFF
--- a/api/models/diffusion.py
+++ b/api/models/diffusion.py
@@ -21,6 +21,8 @@ class ImageGenerationOptions:
     strength: Optional[float] = 1.0
 
     image: PIL.Image.Image = field(default_factory=PIL.Image.Image)
+    hiresfix: bool
+    hiresfix_scale: float
 
     def dict(self):
         return asdict(self)

--- a/api/models/diffusion.py
+++ b/api/models/diffusion.py
@@ -21,8 +21,8 @@ class ImageGenerationOptions:
     strength: Optional[float] = 1.0
 
     image: PIL.Image.Image = field(default_factory=PIL.Image.Image)
-    hiresfix: bool
-    hiresfix_scale: float
+    hiresfix: bool = False
+    hiresfix_scale: float = 1.5
 
     def dict(self):
         return asdict(self)

--- a/api/models/diffusion.py
+++ b/api/models/diffusion.py
@@ -22,6 +22,7 @@ class ImageGenerationOptions:
 
     image: PIL.Image.Image = field(default_factory=PIL.Image.Image)
     hiresfix: bool = False
+    hiresfix_mode: str = "bilinear"
     hiresfix_scale: float = 1.5
 
     def dict(self):

--- a/modules/components/image_generation_options.py
+++ b/modules/components/image_generation_options.py
@@ -91,8 +91,8 @@ def common_options_ui():
 def hires_options_ui():
     with gr.Row():
         with gr.Accordion("Hires.fix", open=False):
+            enable_upscale = gr.Checkbox(label="Hires.fix")
             with gr.Row():
-                enable_upscale = gr.Checkbox(label="Hires.fix")
                 upscaler_mode = gr.Dropdown(
                     choices=[
                         "bilinear",
@@ -105,9 +105,9 @@ def hires_options_ui():
                     value="bilinear",
                     label="Latent upscaler mode",
                 )
-            scale_slider = gr.Slider(
-                value=1.5, minimum=1, maximum=4, step=0.05, label="Upscale by"
-            )
+                scale_slider = gr.Slider(
+                    value=1.5, minimum=1, maximum=4, step=0.05, label="Upscale by"
+                )
     return enable_upscale, upscaler_mode, scale_slider
 
 

--- a/modules/components/image_generation_options.py
+++ b/modules/components/image_generation_options.py
@@ -88,15 +88,22 @@ def common_options_ui():
     )
 
 
+def hires_options_ui():
+    with gr.Row():
+        with gr.Accordion("Hires.fix", open=False):
+            enable_upscale = gr.Checkbox(label="Hires.fix")
+            scale_slider = gr.Slider(
+                value=1.5, minimum=1, maximum=2, step=0.1, label="Scale"
+            )
+    return enable_upscale, scale_slider
+
+
 def img2img_options_ui():
     with gr.Column():
         with gr.Accordion("Img2Img", open=False):
             init_image = gr.Image(label="Init Image", type="pil")
             strength_slider = gr.Slider(
-                value=0.5,
-                minimum=0,
-                maximum=1,
-                step=0.01,
+                value=0.5, minimum=0, maximum=1, step=0.01, label="Strength"
             )
     return init_image, strength_slider
 

--- a/modules/components/image_generation_options.py
+++ b/modules/components/image_generation_options.py
@@ -94,12 +94,19 @@ def hires_options_ui():
             with gr.Row():
                 enable_upscale = gr.Checkbox(label="Hires.fix")
                 upscaler_mode = gr.Dropdown(
-                    choices=["nearest", "bilinear", "bicubic"],
+                    choices=[
+                        "bilinear",
+                        "bilinear-antialiased",
+                        "bicubic",
+                        "bicubic-antialiased",
+                        "nearest",
+                        "nearest-exact",
+                    ],
                     value="bilinear",
                     label="Latent upscaler mode",
                 )
             scale_slider = gr.Slider(
-                value=1.5, minimum=1, maximum=2, step=0.1, label="Scale"
+                value=1.5, minimum=1, maximum=4, step=0.05, label="Upscale by"
             )
     return enable_upscale, upscaler_mode, scale_slider
 

--- a/modules/components/image_generation_options.py
+++ b/modules/components/image_generation_options.py
@@ -91,11 +91,17 @@ def common_options_ui():
 def hires_options_ui():
     with gr.Row():
         with gr.Accordion("Hires.fix", open=False):
-            enable_upscale = gr.Checkbox(label="Hires.fix")
+            with gr.Row():
+                enable_upscale = gr.Checkbox(label="Hires.fix")
+                upscaler_mode = gr.Dropdown(
+                    choices=["nearest", "bilinear", "bicubic"],
+                    value="bilinear",
+                    label="Latent upscaler mode",
+                )
             scale_slider = gr.Slider(
                 value=1.5, minimum=1, maximum=2, step=0.1, label="Scale"
             )
-    return enable_upscale, scale_slider
+    return enable_upscale, upscaler_mode, scale_slider
 
 
 def img2img_options_ui():

--- a/modules/diffusion/pipelines/diffusers.py
+++ b/modules/diffusion/pipelines/diffusers.py
@@ -404,10 +404,11 @@ class DiffusersPipeline:
             ).images
             opts.height = int(opts.height * opts.hiresfix_scale)
             opts.width = int(opts.width * opts.hiresfix_scale)
+
             opts.image = torch.nn.functional.interpolate(
                 opts.image,
                 (opts.height // 8, opts.width // 8),
-                mode=opts.hiresfix_mode,
+                mode=opts.hiresfix_mode.split("-")[0],
                 antialias=True if "antialiased" in opts.hiresfix_mode else False,
             )
             opts.image = self.create_output(opts.image, "pil", True).images[0]

--- a/modules/diffusion/pipelines/diffusers.py
+++ b/modules/diffusion/pipelines/diffusers.py
@@ -405,7 +405,10 @@ class DiffusersPipeline:
             opts.height = int(opts.height * opts.hiresfix_scale)
             opts.width = int(opts.width * opts.hiresfix_scale)
             opts.image = torch.nn.functional.interpolate(
-                opts.image, (opts.height // 8, opts.width // 8), mode=opts.hiresfix_mode
+                opts.image,
+                (opts.height // 8, opts.width // 8),
+                mode=opts.hiresfix_mode,
+                antialias=True if "antialiased" in opts.hiresfix_mode else False,
             )
             opts.image = self.create_output(opts.image, "pil", True).images[0]
 

--- a/modules/diffusion/pipelines/diffusers.py
+++ b/modules/diffusion/pipelines/diffusers.py
@@ -121,6 +121,7 @@ class DiffusersPipeline:
 
         self.plugin_data = None
         self.opts = None
+        self.stage_1st = None
 
     def to(self, device: torch.device = None, dtype: torch.dtype = None):
         if device is None:
@@ -385,7 +386,6 @@ class DiffusersPipeline:
         self.opts = opts
 
         # Hires.fix
-        self.stage_1st = False
         if opts.hiresfix:
             opts.hiresfix, self.stage_1st = False, True
             opts.image = self.__call__(
@@ -491,7 +491,7 @@ class DiffusersPipeline:
             enterer.__exit__(None, None, None)
 
         if self.stage_1st:
-            self.stage_1st = False
+            self.stage_1st = None
             return outputs
 
         self.plugin_data = None

--- a/modules/diffusion/pipelines/diffusers.py
+++ b/modules/diffusion/pipelines/diffusers.py
@@ -385,6 +385,7 @@ class DiffusersPipeline:
         self.opts = opts
 
         # Hires.fix
+        self.stage_1st = False
         if opts.hiresfix:
             opts.hiresfix, self.stage_1st = False, True
             opts.image = self.__call__(
@@ -402,7 +403,7 @@ class DiffusersPipeline:
                 plugin_data,
             ).images
             opts.height = int(opts.height * opts.hiresfix_scale)
-            opts.width = int(opts.hiresfix_scale * opts.hiresfix_scale)
+            opts.width = int(opts.width * opts.hiresfix_scale)
             opts.image = torch.nn.functional.interpolate(
                 opts.image, (opts.height // 8, opts.width // 8), mode="bilinear"
             )

--- a/modules/diffusion/pipelines/diffusers.py
+++ b/modules/diffusion/pipelines/diffusers.py
@@ -405,7 +405,7 @@ class DiffusersPipeline:
             opts.height = int(opts.height * opts.hiresfix_scale)
             opts.width = int(opts.width * opts.hiresfix_scale)
             opts.image = torch.nn.functional.interpolate(
-                opts.image, (opts.height // 8, opts.width // 8), mode="bilinear"
+                opts.image, (opts.height // 8, opts.width // 8), mode=opts.hiresfix_mode
             )
             opts.image = self.create_output(opts.image, "pil", True).images[0]
 

--- a/modules/tabs/generate.py
+++ b/modules/tabs/generate.py
@@ -83,20 +83,18 @@ class Generate(Tab):
 
         count = 0
 
-        hiresfix = opts.hiresfix
+        # pre-calculate inference steps
+        if opts.hiresfix:
+            inference_steps = opts.num_inference_steps + int(
+                opts.num_inference_steps * opts.strength
+            )
+        else:
+            inference_steps = opts.num_inference_steps
+
         for data in model_manager.sd_model(opts, plugin_data):
             if type(data) == tuple:
                 step, preview = data
-                if hiresfix:
-                    progress = step / (
-                        opts.batch_count
-                        * (
-                            opts.num_inference_steps
-                            + int(opts.num_inference_steps * opts.strength)
-                        )
-                    )
-                else:
-                    progress = step / (opts.batch_count * opts.num_inference_steps)
+                progress = step / (opts.batch_count * inference_steps)
                 previews = []
                 for images, opts in preview:
                     previews.extend(images)

--- a/modules/tabs/generate.py
+++ b/modules/tabs/generate.py
@@ -83,10 +83,11 @@ class Generate(Tab):
 
         count = 0
 
+        hiresfix = opts.hiresfix
         for data in model_manager.sd_model(opts, plugin_data):
             if type(data) == tuple:
                 step, preview = data
-                if opts.hiresfix:
+                if hiresfix:
                     progress = step / (
                         opts.batch_count
                         * (

--- a/modules/tabs/generate.py
+++ b/modules/tabs/generate.py
@@ -22,11 +22,13 @@ def generate_fn(fn):
             seed,
             width,
             height,
+            hiresfix,
+            hiresfix_scale,
             init_image,
             strength,
-        ) = as_list[0:12]
+        ) = as_list[0:14]
 
-        plugin_values = dict(list(data.items())[12:])
+        plugin_values = dict(list(data.items())[14:])
 
         opts = ImageGenerationOptions(
             prompt=prompt,
@@ -41,6 +43,8 @@ def generate_fn(fn):
             strength=strength,
             seed=seed,
             image=init_image,
+            hiresfix=hiresfix,
+            hiresfix_scale=hiresfix_scale,
         )
         yield from fn(self, opts, plugin_values)
 
@@ -115,6 +119,7 @@ class Generate(Tab):
                 with gr.Column(scale=1.25):
                     options = image_generation_options.common_options_ui()
 
+                    options += image_generation_options.hires_options_ui()
                     options += image_generation_options.img2img_options_ui()
 
                     plugin_values = image_generation_options.plugin_options_ui()

--- a/modules/tabs/generate.py
+++ b/modules/tabs/generate.py
@@ -23,6 +23,7 @@ def generate_fn(fn):
             width,
             height,
             hiresfix,
+            hiresfix_mode,
             hiresfix_scale,
             init_image,
             strength,
@@ -44,6 +45,7 @@ def generate_fn(fn):
             seed=seed,
             image=init_image,
             hiresfix=hiresfix,
+            hiresfix_mode=hiresfix_mode,
             hiresfix_scale=hiresfix_scale,
         )
         yield from fn(self, opts, plugin_values)

--- a/modules/tabs/generate.py
+++ b/modules/tabs/generate.py
@@ -27,9 +27,9 @@ def generate_fn(fn):
             hiresfix_scale,
             init_image,
             strength,
-        ) = as_list[0:14]
+        ) = as_list[0:15]
 
-        plugin_values = dict(list(data.items())[14:])
+        plugin_values = dict(list(data.items())[15:])
 
         opts = ImageGenerationOptions(
             prompt=prompt,
@@ -86,7 +86,16 @@ class Generate(Tab):
         for data in model_manager.sd_model(opts, plugin_data):
             if type(data) == tuple:
                 step, preview = data
-                progress = step / (opts.batch_count * opts.num_inference_steps)
+                if opts.hiresfix:
+                    progress = step / (
+                        opts.batch_count
+                        * (
+                            opts.num_inference_steps
+                            + int(opts.num_inference_steps * opts.strength)
+                        )
+                    )
+                else:
+                    progress = step / (opts.batch_count * opts.num_inference_steps)
                 previews = []
                 for images, opts in preview:
                     previews.extend(images)


### PR DESCRIPTION
Related issues: #33 
- Add High-res.fix for txt2img and img2img inference
- Support latent upscale mode: `nearest`, `bilinear` and `bicubic`

Tips: Upscale denoise strength share the strength slider with img2img

Still in test, I will give a more detailed instruction after that.