### PR TITLE
Added support for TensorRT>=8.6.0,<8.7.0

### DIFF
--- a/launch.py
+++ b/launch.py
@@ -123,10 +123,12 @@ def install_plugin_deps():
 
 
 def install_tensorrt():
-    trt_version = "8.6.0"
+    trt_version = ">=8.6.0", "<8.7.0"
+    trt_version_list = ("8.6",)
+    trt_version_join = ",".join(trt_version)
     tensorrt_linux_command = os.environ.get(
         "TENSORRT_LINUX_COMMAND",
-        f"pip install tensorrt=={trt_version}",
+        f'pip install "tensorrt{trt_version_join}"',
     )
     if platform.system() == "Windows":
         libfile_path = which("nvinfer.dll")
@@ -144,13 +146,17 @@ def install_tensorrt():
                 filepath = os.path.join(python_dir, file)
                 print("Installing tensorrt")
                 run(f'"{python}" -m pip install "{filepath}"')
+                break
         else:
             raise RuntimeError("Failed to install tensorrt.")
     else:
-        run(f"{python} -m {tensorrt_linux_command}")
+        run(f'"{python}" -m {tensorrt_linux_command}')
 
+    trt_version_assert = " or ".join(
+        [f"v.startswith('{x}.')" for x in trt_version_list]
+    )
     run_python(
-        f"import tensorrt; v = tensorrt.__version__ ; assert v == '{trt_version}', f'Incorrect version of TensorRT. Requires {trt_version} but {{v}} detected.'"
+        f"import tensorrt; v = tensorrt.__version__; assert {trt_version_assert}, f'Incorrect version of TensorRT. Requires {trt_version_join} but {{v}} detected.'"
     )
 
 

--- a/modules/acceleration/tensorrt/engine.py
+++ b/modules/acceleration/tensorrt/engine.py
@@ -2,6 +2,7 @@ import gc
 import os
 
 import torch
+import tensorrt
 
 from api.models.tensorrt import BuildEngineOptions, TensorRTEngineData
 from lib.tensorrt.utilities import (
@@ -30,6 +31,7 @@ class EngineBuilder:
         self.model = model_manager.sd_model
         self.device = "cuda"
         self.opts = opts
+        self.trt_version = tensorrt.__version__
 
         unet = load_unet(self.model.model_id)
         text_encoder = load_text_encoder(self.model.model_id)
@@ -111,6 +113,7 @@ class EngineBuilder:
         torch.cuda.empty_cache()
 
         data = TensorRTEngineData(
+            trt_version=self.trt_version,
             static_batch=self.opts.build_static_batch,
             max_batch_size=self.opts.max_batch_size,
             refit=self.opts.build_enable_refit,


### PR DESCRIPTION
`TensorRT 8.6.0`が公式サイトからダウンロード出来なくなってるみたいです
`8.6.1`にアップデートする代わりに`TensorRT>=8.6.0,<8.7.0`のサポートを追加しました

It looks like `TensorRT 8.6.0` is no longer available for download from the official site.
Instead of updating to `8.6.1`, support for `TensorRT>=8.6.0,<8.7.0` has been added.

versionチェックの実装だけ悩みました
`startswith`で実装しています

I was wondering how to implement the version check.
I implemented it with `startswith`.