### PR TITLE
Support karras samplers

### DIFF
--- a/lib/diffusers/scheduler.py
+++ b/lib/diffusers/scheduler.py
@@ -1,5 +1,6 @@
 import diffusers
 
+# TODO: add rest Auto111 samplers
 SCHEDULERS = {
     "unipc": diffusers.schedulers.UniPCMultistepScheduler,
     "euler_a": diffusers.schedulers.EulerAncestralDiscreteScheduler,
@@ -9,8 +10,24 @@ SCHEDULERS = {
     "deis": diffusers.schedulers.DEISMultistepScheduler,
     "dpm2": diffusers.schedulers.KDPM2DiscreteScheduler,
     "dpm2-a": diffusers.schedulers.KDPM2AncestralDiscreteScheduler,
-    "heun": diffusers.schedulers.DPMSolverMultistepScheduler,
-    "dpm++": diffusers.schedulers.DPMSolverMultistepScheduler,
-    "dpm": diffusers.schedulers.DPMSolverMultistepScheduler,
+    "dpm++_2s": diffusers.schedulers.DPMSolverSinglestepScheduler,
+    "dpm++_2m": diffusers.schedulers.DPMSolverMultistepScheduler,
+    "dpm++_2m_karras": diffusers.schedulers.DPMSolverMultistepScheduler,
+    "dpm++_sde": diffusers.schedulers.DPMSolverSDEScheduler,
+    "dpm++_sde_karras": diffusers.schedulers.DPMSolverSDEScheduler,
+    "heun": diffusers.schedulers.HeunDiscreteScheduler,
+    "heun_karras": diffusers.schedulers.HeunDiscreteScheduler,
+    "lms": diffusers.schedulers.LMSDiscreteScheduler,
+    # "lms_karras": diffusers.schedulers.LMSDiscreteScheduler, # still unreleased in diffusers 0.16.0
     "pndm": diffusers.schedulers.PNDMScheduler,
 }
+
+
+def parser_schedulers_config(scheduler_id: str):
+    """
+    add extra config parameter to scheduler
+    """
+    kwargs = {}
+    if "karras" in scheduler_id:
+        kwargs["use_karras_sigmas"] == True
+    return kwargs

--- a/lib/diffusers/scheduler.py
+++ b/lib/diffusers/scheduler.py
@@ -30,5 +30,5 @@ def parser_schedulers_config(scheduler_id: str):
     """
     kwargs = {}
     if "karras" in scheduler_id:
-        kwargs["use_karras_sigmas"] == True
+        kwargs["use_karras_sigmas"] = True
     return kwargs

--- a/lib/diffusers/scheduler.py
+++ b/lib/diffusers/scheduler.py
@@ -1,6 +1,7 @@
 import diffusers
 
 # TODO: add rest Auto111 samplers
+# Commented schedulers are still unavailable in diffusers 0.16.1
 SCHEDULERS = {
     "unipc": diffusers.schedulers.UniPCMultistepScheduler,
     "euler_a": diffusers.schedulers.EulerAncestralDiscreteScheduler,
@@ -13,12 +14,12 @@ SCHEDULERS = {
     "dpm++_2s": diffusers.schedulers.DPMSolverSinglestepScheduler,
     "dpm++_2m": diffusers.schedulers.DPMSolverMultistepScheduler,
     "dpm++_2m_karras": diffusers.schedulers.DPMSolverMultistepScheduler,
-    "dpm++_sde": diffusers.schedulers.DPMSolverSDEScheduler,
-    "dpm++_sde_karras": diffusers.schedulers.DPMSolverSDEScheduler,
+    # "dpm++_sde": diffusers.schedulers.DPMSolverSDEScheduler,
+    # "dpm++_sde_karras": diffusers.schedulers.DPMSolverSDEScheduler,
     "heun": diffusers.schedulers.HeunDiscreteScheduler,
     "heun_karras": diffusers.schedulers.HeunDiscreteScheduler,
     "lms": diffusers.schedulers.LMSDiscreteScheduler,
-    # "lms_karras": diffusers.schedulers.LMSDiscreteScheduler, # still unreleased in diffusers 0.16.0
+    # "lms_karras": diffusers.schedulers.LMSDiscreteScheduler,
     "pndm": diffusers.schedulers.PNDMScheduler,
 }
 

--- a/modules/model.py
+++ b/modules/model.py
@@ -8,7 +8,7 @@ from typing import *
 import torch
 
 from api.models.diffusion import ImageGenerationOptions
-from lib.diffusers.scheduler import SCHEDULERS
+from lib.diffusers.scheduler import SCHEDULERS, parser_schedulers_config
 
 from . import config, utils
 from .images import save_image
@@ -133,7 +133,7 @@ class DiffusersModel:
         if not self.activated:
             raise RuntimeError("Model not activated")
         self.pipe.scheduler = SCHEDULERS[scheduler_id].from_config(
-            self.pipe.scheduler.config
+            self.pipe.scheduler.config, **parser_schedulers_config(scheduler_id)
         )
 
     def __call__(self, opts: ImageGenerationOptions, plugin_data: Dict[str, List] = {}):


### PR DESCRIPTION
- Fix mismatched schedulers
- Rename `DPM++` samplers to Auto111 format.
- Add new samplers: `LMS`, `DPM++ 2S` and `DPM++ SDE`
- Support karras samplers to `DPM++ 2M`, `DPM++ SDE` and `Heun`.