### PR TITLE
Refactor Multi-diffusion to support tile batch

### DIFF
--- a/api/models/diffusion.py
+++ b/api/models/diffusion.py
@@ -6,6 +6,21 @@ import PIL.Image
 
 
 @dataclass
+class HiresfixOptions:
+    enable: bool = False
+    mode: str = "bilinear"
+    scale: float = 1.5
+
+
+@dataclass
+class MultidiffusionOptions:
+    enable: bool = False
+    views_batch_size: int = 1
+    window_size: int = 64
+    stride: int = 8
+
+
+@dataclass
 class ImageGenerationOptions:
     # serializable
     prompt: str
@@ -22,10 +37,8 @@ class ImageGenerationOptions:
 
     image: PIL.Image.Image = field(default_factory=PIL.Image.Image)
 
-    hiresfix: bool = False
-    hiresfix_mode: str = "bilinear"
-    hiresfix_scale: float = 1.5
-    multidiffusion: bool = False
+    hiresfix: HiresfixOptions = None
+    multidiffusion: MultidiffusionOptions = None
 
     def dict(self):
         return asdict(self)

--- a/api/models/tensorrt.py
+++ b/api/models/tensorrt.py
@@ -1,4 +1,3 @@
-from dataclasses import dataclass
 from typing import *
 
 from pydantic import BaseModel
@@ -24,7 +23,6 @@ class BuildEngineOptions(BaseModel):
     full_acceleration = False
 
 
-@dataclass
 class TensorRTEngineData(BaseModel):
     trt_version: str = "8.6.0"
     max_batch_size: int = 1

--- a/api/models/tensorrt.py
+++ b/api/models/tensorrt.py
@@ -1,3 +1,4 @@
+from dataclasses import dataclass
 from typing import *
 
 from pydantic import BaseModel
@@ -23,6 +24,7 @@ class BuildEngineOptions(BaseModel):
     full_acceleration = False
 
 
+@dataclass
 class TensorRTEngineData(BaseModel):
     trt_version: str = "8.6.0"
     max_batch_size: int = 1

--- a/modules/components/image_generation_options.py
+++ b/modules/components/image_generation_options.py
@@ -90,29 +90,55 @@ def common_options_ui():
     )
 
 
-def hires_options_ui():
+def upscale_options_ui():
     with gr.Row():
         with gr.Accordion("Upscaler", open=False):
             with gr.Row():
                 enable_hires = gr.Checkbox(label="Hires.fix")
                 enable_multidiff = gr.Checkbox(label="Multi-Diffusion")
-            with gr.Row():
-                upscaler_mode = gr.Dropdown(
-                    choices=[
-                        "bilinear",
-                        "bilinear-antialiased",
-                        "bicubic",
-                        "bicubic-antialiased",
-                        "nearest",
-                        "nearest-exact",
-                    ],
-                    value="bilinear",
-                    label="Latent upscaler mode",
-                )
-                scale_slider = gr.Slider(
-                    value=1.5, minimum=1, maximum=4, step=0.05, label="Upscale by"
-                )
-    return enable_hires, enable_multidiff, upscaler_mode, scale_slider
+            with gr.Accordion("Hires.fix Options", open=False):
+                with gr.Row():
+                    upscaler_mode = gr.Dropdown(
+                        choices=[
+                            "bilinear",
+                            "bilinear-antialiased",
+                            "bicubic",
+                            "bicubic-antialiased",
+                            "nearest",
+                            "nearest-exact",
+                        ],
+                        value="bilinear",
+                        label="Latent upscaler mode",
+                    )
+                    scale_slider = gr.Slider(
+                        value=1.5, minimum=1, maximum=4, step=0.05, label="Upscale by"
+                    )
+            with gr.Accordion("Multi-Diffusion Options", open=False):
+                with gr.Row():
+                    views_batch_size = gr.Slider(
+                        value=4, minimum=1, maximum=32, step=1, label="tile batch size"
+                    )
+                with gr.Row():
+                    window_size = gr.Slider(
+                        value=64,
+                        minimum=64,
+                        maximum=96,
+                        step=8,
+                        label="window size (latent)",
+                    )
+                    stride = gr.Slider(
+                        value=16, minimum=8, maximum=64, step=8, label="stride (latent)"
+                    )
+
+    return (
+        enable_hires,
+        enable_multidiff,
+        upscaler_mode,
+        scale_slider,
+        views_batch_size,
+        window_size,
+        stride,
+    )
 
 
 def img2img_options_ui():

--- a/modules/components/image_generation_options.py
+++ b/modules/components/image_generation_options.py
@@ -122,7 +122,7 @@ def upscale_options_ui():
                     window_size = gr.Slider(
                         value=64,
                         minimum=64,
-                        maximum=96,
+                        maximum=128,
                         step=8,
                         label="window size (latent)",
                     )

--- a/modules/diffusion/pipelines/tensorrt.py
+++ b/modules/diffusion/pipelines/tensorrt.py
@@ -159,9 +159,10 @@ class TensorRTStableDiffusionPipeline(DiffusersPipeline):
     ):
         super().load_resources(opts)
         image_height, image_width, batch_size = opts.height, opts.width, opts.batch_size
-        if opts.multidiffusion:
-            # TODO: adjustable tile H and W
-            image_height, image_width = 512, 512
+        if opts.multidiffusion.enable:
+            tile_size = opts.multidiffusion.window_size * 8
+            image_height, image_width = tile_size, tile_size
+            batch_size = opts.multidiffusion.views_batch_size
         self.unet.allocate_buffers(
             shape_dict=self.trt_models["unet"].get_shape_dict(
                 batch_size, image_height, image_width

--- a/modules/diffusion/upscalers/multidiffusion.py
+++ b/modules/diffusion/upscalers/multidiffusion.py
@@ -107,7 +107,7 @@ class Multidiffusion:
                     latent_model_input = (
                         latents_for_view.repeat_interleave(2, dim=0)
                         if do_classifier_free_guidance
-                        else latents
+                        else latents_for_view
                     )
                     latent_model_input = self.scheduler.scale_model_input(
                         latent_model_input, timestep


### PR DESCRIPTION
- Refactor Multi-diffusion to support tile batch for faster generation speed
- Make `windows size` and `stride` adjustable for Multi-diffusion

Still in test for TensorRT.

### Parameters recommendation
- Recommend `windows size=64` for sd-v1.4/1.5 and `windows size=96` for sd-v2.
- Recommend `stride=8` for more detailed image and `stride=16` for faster generation speed. Personally, higher stride is not recommended for Multi-diffusion.