### PR TITLE
add pydantic requirements

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -7,6 +7,7 @@ invisible-watermark==0.2.0
 accelerate==0.18.0
 transformers==4.28.1
 sentencepiece~=0.1
+pydantic==2.3.0
 omegaconf
 safetensors
 


### PR DESCRIPTION
pydantic の要件が欠落していました。
依存関係に FastAPI があるので自動的にダウンロードされていました。
FastAPI の pydantic の要件は `>=1.7.4,<3.0.0,!=2.1.0,!=2.0.1,!=2.0.0,!=1.8.1,!=1.8` で Radiata の要件は `>=2.0.0, <=3.0.0` です。(要検証)
そのため、運が悪かったり pydantic の v2 リリース前に制作した環境ではエラーが発生します。



The pydantic requirement was missing.
It was automatically downloaded because of the FastAPI dependency.
FastAPI's pydantic requirements are `>=1.7.4,<3.0.0,! =2.1.0,! =2.0.1,! =2.0.0,! =1.8.1,! =1.8` and Radiata requirements are `>=2.0.0, <=3.0.0`. (verification required)
So, if you are unlucky or if your environment was created before pydantic's v2 release, you will get an error.

